### PR TITLE
Add a RatPack Kafka consumer module.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,12 +22,21 @@ dependencies:
 test:
   pre:
     - docker-compose up -d
+    - ./etc/ci/wait_for_socket.py --timeout=60 --port=2281
+    - ./etc/ci/wait_for_socket.py --timeout=60 --port=9092
+    - sleep 30
   override:
+    # Seem to be running into https://issues.apache.org/jira/browse/KAFKA-3296
+    # Run tests to 'warm' kafka but don't check for failures.
+    - ./gradlew :ratpack-kafka-consumer:check || true
+
+    # Run tests for realz.
     - ./gradlew check jacocoTestReport
 
   post:
     - 'find . -type f -name "*.xml" | grep "build/test-results" | xargs cp -t $CIRCLE_TEST_REPORTS/'
     - bash <(curl -s https://codecov.io/bash)
+    - docker-compose logs >> $CIRCLE_ARTIFACTS/docker-compose.log
 
 deployment:
   snapshot:

--- a/etc/ci/wait_for_socket.py
+++ b/etc/ci/wait_for_socket.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+import argparse
+import socket
+import time
+import sys
+
+def main(timeout, poll, host, port):
+	print "Attempting to connect to {}:{} ...".format(host, port)
+	wait_time = 0
+	while True:
+		s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+		try:
+			s.connect((host, port))
+			print "Connected successfully after {} seconds".format(wait_time)
+			s.close()
+			return 0
+		except socket.error:
+			print "Error connecting after {} seconds".format(wait_time)
+		sys.stdout.flush()
+		wait_time += poll
+		if wait_time <= timeout:
+			time.sleep(poll)
+		else:
+			print "Unable to connect. Exiting."
+			return 1
+
+if __name__ == '__main__':
+	p = argparse.ArgumentParser()
+	p.add_argument('--timeout', default=20, type=int, help='How long to wait until failing (seconds)')
+	p.add_argument('--poll', default=2, type=int, help='How often to poll server')
+	p.add_argument('--host', default='127.0.0.1', help='Which host to connect to')
+	p.add_argument('--port', default=9042, type=int, help='Which port to connect to')
+	args = p.parse_args()
+	sys.exit(main(args.timeout, args.poll, args.host, args.port))

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 slf4jVersion=1.7.12
 groovyVersion=2.4.4
 ratpackVersion=1.3.3
+kafkaClientVersion=0.10.0.0

--- a/ratpack-kafka-consumer/build.gradle
+++ b/ratpack-kafka-consumer/build.gradle
@@ -1,10 +1,10 @@
 dependencies {
 	compile "io.ratpack:ratpack-core:${ratpackVersion}"
 	compile "io.ratpack:ratpack-guice:${ratpackVersion}"
-
 	compile "org.apache.kafka:kafka-clients:${kafkaClientVersion}"
-
 	testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
 	testCompile "io.ratpack:ratpack-groovy-test:${ratpackVersion}"
-
+	testCompile 'cglib:cglib-nodep:3.2.4'
+	testRuntime "org.slf4j:slf4j-api:${slf4jVersion}"
+	testRuntime 'ch.qos.logback:logback-classic:1.1.7'
 }

--- a/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/Consumer.java
+++ b/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/Consumer.java
@@ -1,0 +1,57 @@
+package smartthings.ratpack.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import ratpack.func.Action;
+
+import java.util.Properties;
+
+/**
+ * Interface for creating a Kafka Consumer.  Implementers will have their consume method called as messages become
+ * available.
+ * @param <K> Key deserialization class.
+ * @param <V> Value deserialization class.
+ */
+public interface Consumer<K, V> {
+	/**
+	 * Method will be called on successful Kafka poll with fetched messages.
+	 * @param records
+	 */
+	void consume(ConsumerRecords<K, V> records) throws Exception;
+
+	/**
+	 * Kafka topics in which to subscribe.
+	 * @return
+	 */
+	String[] getTopics();
+
+	/**
+	 * Kafka Consumer Group ID.
+	 * @return
+	 */
+	String getGroup();
+
+	/**
+	 * Determines how many consumers will be spun up on application start.
+	 * @return
+     */
+	default Integer getConcurrencyLevel() {
+		return 1;
+	}
+
+	/**
+	 * The frequency at which the Kafka consumer client internally polls.
+	 * See Apache\'s KafkaConsumer::poll(long timeout)
+	 * @return
+     */
+	default Long getPollWaitTime() {
+		return Long.MAX_VALUE;
+	}
+
+	/**
+	 * Kafka Consumer property overrides.
+	 * @return
+	 */
+	default Properties getKafkaProperties() {
+		return new Properties();
+	}
+}

--- a/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/ConsumerAction.java
+++ b/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/ConsumerAction.java
@@ -1,0 +1,82 @@
+package smartthings.ratpack.kafka;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.errors.WakeupException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ratpack.exec.Blocking;
+import ratpack.exec.Execution;
+import ratpack.exec.Promise;
+import ratpack.func.Action;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Properties;
+
+/**
+ * Action definition for continuous polling of Kafka messages.
+ */
+class ConsumerAction implements Action<Execution> {
+
+	private static final Logger log = LoggerFactory.getLogger(ConsumerAction.class);
+
+	private final Consumer consumer;
+	private final KafkaConsumerModule.Config config;
+	private final KafkaConsumer client;
+
+	ConsumerAction(Consumer consumer, KafkaConsumerModule.Config config) {
+		this.consumer = consumer;
+		this.config = config;
+		this.client = new KafkaConsumer(getKafkaProperties());
+	}
+
+	void shutdown() {
+		client.wakeup();
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void execute(Execution execution) throws Exception {
+		client.subscribe(new HashSet<>(Arrays.asList(consumer.getTopics())));
+
+		poll().
+			result(r -> {
+				if (r.isError()) {
+					Throwable error = r.getThrowable();
+					if (error instanceof WakeupException) {
+						log.warn("KafkaConsumer is shutting down " + toString());
+					} else {
+						log.error("UnexpectedError KafkaConsumer is shutting down " + toString(), error);
+					}
+					client.close();
+				}
+			});
+	}
+
+	@SuppressWarnings("unchecked")
+	private Promise<?> poll() {
+		return Blocking.get(() -> client.poll(consumer.getPollWaitTime()))
+			.operation(consumer::consume)
+			.flatMap(this::poll);
+	}
+
+	private Properties getKafkaProperties() {
+		// Apply default values.
+		Properties props = config.getKafkaProperties();
+		props.put("group.id", consumer.getGroup());
+
+		// Apply overrides
+		props.putAll(consumer.getKafkaProperties());
+
+		return props;
+	}
+
+	@Override
+	public String toString() {
+		return "Consumer{" +
+				"class=" + consumer.getClass().getSimpleName() +
+				", topics=[" + String.join(",", Arrays.asList(consumer.getTopics())) + "]" +
+				", group=" + consumer.getGroup() +
+				'}';
+	}
+}

--- a/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/KafkaConsumerModule.java
+++ b/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/KafkaConsumerModule.java
@@ -1,0 +1,42 @@
+package smartthings.ratpack.kafka;
+
+import com.google.inject.Scopes;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import ratpack.guice.ConfigurableModule;
+
+import java.util.Properties;
+import java.util.Set;
+
+public class KafkaConsumerModule extends ConfigurableModule<KafkaConsumerModule.Config> {
+
+	protected void configure() {
+		bind(KafkaConsumerService.class).in(Scopes.SINGLETON);
+	}
+
+	public static class Config {
+
+		Set<String> servers;
+
+		public Config() {
+		}
+
+		public Properties getKafkaProperties() {
+			Properties props = new Properties();
+
+			props.put("bootstrap.servers", String.join(",", servers));
+			props.put("key.deserializer", ByteArrayDeserializer.class.getName());
+			props.put("value.deserializer", ByteArrayDeserializer.class.getName());
+
+			return props;
+		}
+
+		public Set<String> getServers() {
+			return servers;
+		}
+
+		public void setServers(Set<String> servers) {
+			this.servers = servers;
+		}
+	}
+
+}

--- a/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/KafkaConsumerService.java
+++ b/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/KafkaConsumerService.java
@@ -1,0 +1,57 @@
+package smartthings.ratpack.kafka;
+
+import com.google.common.reflect.TypeToken;
+import com.google.inject.Inject;
+import ratpack.exec.Execution;
+import ratpack.service.Service;
+import ratpack.service.StartEvent;
+import ratpack.service.StopEvent;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.IntStream;
+
+/**
+ * Service responsible for managing the lifecycle of all Kafka Consumer implementations defined within Registry.
+ */
+public class KafkaConsumerService implements Service {
+
+	private KafkaConsumerModule.Config config;
+	private List<ConsumerAction> actions = new ArrayList<>();
+
+	@Inject
+	public KafkaConsumerService(KafkaConsumerModule.Config config) {
+		this.config = config;
+	}
+
+	@Override
+	public void onStart(StartEvent event) {
+		// Find all configured Consumer implementations from Registry.
+		Iterator<? extends Consumer> it = event.getRegistry().getAll(TypeToken.of(Consumer.class)).iterator();
+
+		// Populate our actions in accordance with the desired concurrency level.
+		if (it != null && it.hasNext()){
+			it.forEachRemaining(consumer -> {
+				int concurrency = consumer.getConcurrencyLevel();
+
+				IntStream
+					.rangeClosed(1, concurrency)
+					.forEach((action) -> actions.add(new ConsumerAction(consumer, config)));
+			});
+		}
+
+		// Kick off a new execution for each defined consumer.
+		if (!actions.isEmpty()) {
+			actions.forEach((action) -> Execution.fork().start(action));
+		}
+	}
+
+
+	@Override
+	public void onStop(StopEvent event) {
+		if (!actions.isEmpty()) {
+			actions.forEach(ConsumerAction::shutdown);
+		}
+	}
+}

--- a/ratpack-kafka-consumer/src/test/groovy/smartthings/ratpack/kafka/KafkaConsumerServiceSpec.groovy
+++ b/ratpack-kafka-consumer/src/test/groovy/smartthings/ratpack/kafka/KafkaConsumerServiceSpec.groovy
@@ -1,0 +1,83 @@
+package smartthings.ratpack.kafka
+
+import groovy.util.logging.Slf4j
+import ratpack.groovy.test.embed.GroovyEmbeddedApp
+import ratpack.guice.Guice
+import ratpack.test.embed.EmbeddedApp
+import smartthings.ratpack.kafka.fixtures.TestConsumer
+import smartthings.ratpack.kafka.fixtures.TestData
+import smartthings.ratpack.kafka.fixtures.TestProducerService
+import smartthings.ratpack.kafka.fixtures.TestService
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+import spock.util.concurrent.BlockingVariable
+
+import java.time.Instant
+
+@Slf4j
+class KafkaConsumerServiceSpec extends Specification {
+
+	String getTestKafkaServers() {
+		return System.getenv("KAFKA_SERVER") ?: '127.0.0.1:9092'
+	}
+
+	private static final String CLIENT_ID = 'test-client'
+	private static final String GROUP_ID = 'test-client'
+	private static final String TOPIC = 'test'
+
+	private static final TestData data = new TestData(id: UUID.randomUUID().toString(), name: 'Hello World', timestamp: Instant.now().toEpochMilli())
+
+	TestService testService = Mock(TestService)
+
+	TestConsumer testConsumer = new TestConsumer(testService, GROUP_ID, TOPIC)
+
+	@AutoCleanup
+	@Delegate
+	EmbeddedApp app = GroovyEmbeddedApp.of({ spec ->
+		registry(Guice.registry { bindings ->
+			bindings.moduleConfig(KafkaConsumerModule, new KafkaConsumerModule.Config(), { config ->
+				config.setServers([getTestKafkaServers()] as Set<String>)
+			})
+			bindings.bindInstance(TestService, testService)
+			bindings.bindInstance(TestConsumer, testConsumer)
+			bindings.bindInstance(
+				TestProducerService,
+				new TestProducerService([getTestKafkaServers()] as Set<String>, CLIENT_ID, TOPIC)
+			)
+		})
+		handlers {
+			post('produce') { ctx ->
+				TestProducerService producer = ctx.get(TestProducerService)
+				try {
+					producer.send(data)
+						.then({
+						ctx.render('ok')
+					})
+				} catch (Throwable t) {
+					ctx.error(t)
+				}
+			}
+		}
+	})
+
+	void 'it should consumer Kafka messages'() {
+		given:
+		def done = new BlockingVariable(90)
+
+		and:
+		testService.run(_ as TestData) >> { data ->
+			return done.set(data.first())
+		}
+
+		when:
+		String status = httpClient.postText('produce')
+
+		then:
+		log.debug("The call to the producer finished - [status: ${status}]")
+		assert status == 'ok'
+		def result = done.get()
+		assert result.id == data.id
+		assert result.name == data.name
+		assert result.timestamp == data.timestamp
+	}
+}

--- a/ratpack-kafka-consumer/src/test/groovy/smartthings/ratpack/kafka/fixtures/TestConsumer.groovy
+++ b/ratpack-kafka-consumer/src/test/groovy/smartthings/ratpack/kafka/fixtures/TestConsumer.groovy
@@ -1,0 +1,53 @@
+package smartthings.ratpack.kafka.fixtures
+
+import com.google.inject.Inject
+import groovy.util.logging.Slf4j
+import org.apache.kafka.clients.consumer.ConsumerRecords
+import smartthings.ratpack.kafka.Consumer
+
+@Slf4j
+class TestConsumer implements Consumer<byte[], byte[]> {
+
+	final String group
+	final String[] topics
+
+	TestService testService
+
+	@Inject
+	TestConsumer(TestService testService, String group, String topic) {
+		this.testService = testService
+		this.group = group
+		this.topics = [ topic ]
+	}
+
+	@Override
+	void consume(ConsumerRecords<byte[], byte[]> records) throws Exception {
+		log.debug("Consuming records. [size: ${records.size()}]")
+		records.each { record ->
+			ByteArrayInputStream bais
+			ObjectInput oi
+			try {
+				bais = new ByteArrayInputStream(record.value());
+				oi = new ObjectInputStream(bais);
+				TestData data = (TestData) oi.readObject()
+				log.debug("Consuming a record. [data: ${data.toString()}]")
+				testService.run(data)
+			} catch (IOException e) {
+				throw e
+			} finally {
+				if (oi) {
+					oi.close()
+				}
+				if (bais) {
+					bais.close()
+				}
+			}
+
+
+		}
+	}
+
+	Long getPollWaitTime() {
+		return 3000
+	}
+}

--- a/ratpack-kafka-consumer/src/test/groovy/smartthings/ratpack/kafka/fixtures/TestData.groovy
+++ b/ratpack-kafka-consumer/src/test/groovy/smartthings/ratpack/kafka/fixtures/TestData.groovy
@@ -1,0 +1,12 @@
+package smartthings.ratpack.kafka.fixtures
+
+import groovy.transform.ToString
+
+@ToString
+class TestData implements Serializable {
+	static final long serialVersionUID = 1L;
+
+	String id
+	String name
+	Long timestamp
+}

--- a/ratpack-kafka-consumer/src/test/groovy/smartthings/ratpack/kafka/fixtures/TestProducerService.groovy
+++ b/ratpack-kafka-consumer/src/test/groovy/smartthings/ratpack/kafka/fixtures/TestProducerService.groovy
@@ -1,0 +1,77 @@
+package smartthings.ratpack.kafka.fixtures
+
+import groovy.util.logging.Slf4j
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.RecordMetadata
+import ratpack.exec.Blocking
+import ratpack.exec.Promise
+import ratpack.service.Service
+import ratpack.service.StartEvent
+import ratpack.service.StopEvent
+
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.TimeUnit
+
+@Slf4j
+class TestProducerService implements Service {
+
+	KafkaProducer<byte[], byte[]> kafkaProducer
+	Set<String> servers
+	String clientId
+	String topic
+
+	TestProducerService(Set<String> servers, String clientId, String topic) {
+		this.servers = servers
+		this.clientId = clientId
+		this.topic = topic
+	}
+
+	@Override
+	public void onStart(StartEvent event) throws Exception {
+		kafkaProducer = new KafkaProducer<>(getKafkaProperties())
+		kafkaProducer.partitionsFor("test")
+	}
+
+	@Override
+	public void onStop(StopEvent event) throws Exception {
+		kafkaProducer.close()
+	}
+
+	public Promise<RecordMetadata> send(TestData data) {
+		byte[] key = data.id.getBytes(StandardCharsets.UTF_8)
+		byte[] value
+		ByteArrayOutputStream baos
+		ObjectOutputStream oos
+		try {
+			baos = new ByteArrayOutputStream()
+			oos = new ObjectOutputStream(baos)
+			oos.writeObject(data)
+			value = baos.toByteArray()
+		} finally {
+			if (oos) {
+				oos.close()
+			}
+
+			if (baos) {
+				baos.close()
+			}
+		}
+
+		return Blocking.get({
+			log.debug("Sending a message. [topic: ${topic}, data: ${data}]")
+			kafkaProducer.send(new ProducerRecord<>(topic, key, value)).get()
+		});
+	}
+
+	Properties getKafkaProperties() {
+		Properties props = new Properties()
+		props.put('bootstrap.servers', String.join(',', servers))
+		props.put('client.id', clientId)
+		props.put('key.serializer', 'org.apache.kafka.common.serialization.ByteArraySerializer')
+		props.put('value.serializer', 'org.apache.kafka.common.serialization.ByteArraySerializer')
+		props.put('max.block.ms', TimeUnit.MINUTES.toMillis(1))
+		return props
+	}
+
+}

--- a/ratpack-kafka-consumer/src/test/groovy/smartthings/ratpack/kafka/fixtures/TestService.groovy
+++ b/ratpack-kafka-consumer/src/test/groovy/smartthings/ratpack/kafka/fixtures/TestService.groovy
@@ -1,0 +1,8 @@
+package smartthings.ratpack.kafka.fixtures
+
+class TestService {
+
+	void run(TestData data) {
+
+	}
+}

--- a/ratpack-kafka-consumer/src/test/resources/logback.xml
+++ b/ratpack-kafka-consumer/src/test/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<!-- encoders are assigned the type ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+		<encoder>
+			<pattern>time=%d{HH:mm:ss.SSS}, loggingId=%X{loggingId}, level=%-5level, logger=%logger{36}, message=%msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<root level="DEBUG">
+		<appender-ref ref="STDOUT" />
+	</root>
+</configuration>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 include 'ratpack-kafka-producer'
+include 'ratpack-kafka-consumer'
 
 rootProject.name='ratpack-kafka-parent'
 


### PR DESCRIPTION
Adds a basic implementation for a Ratpack Kafka Consumer plugin.
An end user would essentially bind the packaged Guice module on startup, and provide an implementation of the provided Consumer interface.

I'd like to follow up this base / foundational PR w/ some circuit breaker / event listener logic that I'd attempt to port from the https://github.com/SmartThingsOSS/konsumer project.
