### PR TITLE
Add a simple circuit breaker for suspending / resuming all consumers.

### DIFF
--- a/ratpack-kafka-consumer/build.gradle
+++ b/ratpack-kafka-consumer/build.gradle
@@ -2,6 +2,8 @@ dependencies {
 	compile "io.ratpack:ratpack-core:${ratpackVersion}"
 	compile "io.ratpack:ratpack-guice:${ratpackVersion}"
 	compile "org.apache.kafka:kafka-clients:${kafkaClientVersion}"
+	compile 'com.google.code.findbugs:jsr305:3.0.0'
+
 	testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
 	testCompile "io.ratpack:ratpack-groovy-test:${ratpackVersion}"
 	testCompile 'cglib:cglib-nodep:3.2.4'

--- a/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/Consumer.java
+++ b/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/Consumer.java
@@ -2,6 +2,7 @@ package smartthings.ratpack.kafka;
 
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import ratpack.func.Action;
+import smartthings.ratpack.kafka.event.KafkaConsumerEvent;
 
 import java.util.Properties;
 
@@ -33,7 +34,7 @@ public interface Consumer<K, V> {
 	/**
 	 * Determines how many consumers will be spun up on application start.
 	 * @return
-     */
+	 */
 	default Integer getConcurrencyLevel() {
 		return 1;
 	}
@@ -42,7 +43,7 @@ public interface Consumer<K, V> {
 	 * The frequency at which the Kafka consumer client internally polls.
 	 * See Apache\'s KafkaConsumer::poll(long timeout)
 	 * @return
-     */
+	 */
 	default Long getPollWaitTime() {
 		return Long.MAX_VALUE;
 	}
@@ -54,4 +55,10 @@ public interface Consumer<K, V> {
 	default Properties getKafkaProperties() {
 		return new Properties();
 	}
+
+	/**
+	 * Event handler called on state changes to the kafka consumer.
+	 * @param event
+	 */
+	default void eventHandler(KafkaConsumerEvent event) {}
 }

--- a/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/KafkaConsumerModule.java
+++ b/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/KafkaConsumerModule.java
@@ -3,6 +3,8 @@ package smartthings.ratpack.kafka;
 import com.google.inject.Scopes;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import ratpack.guice.ConfigurableModule;
+import smartthings.ratpack.kafka.circuitbreaker.CircuitBreaker;
+import smartthings.ratpack.kafka.circuitbreaker.SimpleCircuitBreaker;
 
 import java.util.Properties;
 import java.util.Set;
@@ -14,6 +16,7 @@ public class KafkaConsumerModule extends ConfigurableModule<KafkaConsumerModule.
 
 	protected void configure() {
 		bind(KafkaConsumerService.class).in(Scopes.SINGLETON);
+		bind(CircuitBreaker.class).toProvider(SimpleCircuitBreaker::new);
 	}
 
 	/**

--- a/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/KafkaConsumerService.java
+++ b/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/KafkaConsumerService.java
@@ -6,6 +6,10 @@ import ratpack.exec.Execution;
 import ratpack.service.Service;
 import ratpack.service.StartEvent;
 import ratpack.service.StopEvent;
+import smartthings.ratpack.kafka.circuitbreaker.CircuitBreaker;
+import smartthings.ratpack.kafka.circuitbreaker.CircuitBreakerListener;
+import smartthings.ratpack.kafka.event.KafkaConsumerEvent;
+import smartthings.ratpack.kafka.event.KafkaConsumerEventListener;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -19,6 +23,8 @@ public class KafkaConsumerService implements Service {
 
 	private KafkaConsumerModule.Config config;
 	private List<ConsumerAction> actions = new ArrayList<>();
+	private List<KafkaConsumerEventListener> listeners = new ArrayList<>();
+	private CircuitBreaker circuitBreaker;
 
 	@Inject
 	public KafkaConsumerService(KafkaConsumerModule.Config config) {
@@ -29,15 +35,28 @@ public class KafkaConsumerService implements Service {
 	public void onStart(StartEvent event) {
 		// Find all configured Consumer implementations from Registry.
 		Iterator<? extends Consumer> it = event.getRegistry().getAll(TypeToken.of(Consumer.class)).iterator();
+		circuitBreaker = event.getRegistry().get(CircuitBreaker.class);
+		circuitBreaker.init(new CircuitBreakerListener() {
+			@Override
+			public void opened() {
+				notifyEventListeners(KafkaConsumerEvent.SUSPENDED_EVENT);
+			}
+
+			@Override
+			public void closed() {
+				notifyEventListeners(KafkaConsumerEvent.RESUMED_EVENT);
+			}
+		});
 
 		// Populate our actions in accordance with the desired concurrency level.
 		if (it != null && it.hasNext()){
 			it.forEachRemaining(consumer -> {
 				int concurrency = consumer.getConcurrencyLevel();
+				registerEventListener((e) -> consumer.eventHandler(e));
 
 				IntStream
 					.rangeClosed(1, concurrency)
-					.forEach((action) -> actions.add(new ConsumerAction(consumer, config)));
+					.forEach((action) -> actions.add(new ConsumerAction(consumer, config, circuitBreaker)));
 			});
 		}
 
@@ -45,13 +64,57 @@ public class KafkaConsumerService implements Service {
 		if (!actions.isEmpty()) {
 			actions.forEach((action) -> Execution.fork().start(action));
 		}
-	}
 
+		notifyEventListeners(KafkaConsumerEvent.STARTED_EVENT);
+	}
 
 	@Override
 	public void onStop(StopEvent event) {
 		if (!actions.isEmpty()) {
 			actions.forEach(ConsumerAction::shutdown);
 		}
+		notifyEventListeners(KafkaConsumerEvent.STOPPED_EVENT);
+	}
+
+	/**
+	 * Suspend polling on all KafkaConsumers.
+	 */
+	public void suspend() {
+		if (circuitBreaker == null) {
+			throw new IllegalStateException("KafkaConsumerService is missing circuit breaker.");
+		}
+		circuitBreaker.open();
+	}
+
+	/**
+	 * Informs on whether all KafkaConsumers are suspended.
+	 */
+	public boolean isSuspended() {
+		if (circuitBreaker == null) {
+			throw new IllegalStateException("KafkaConsumerService is missing circuit breaker.");
+		}
+		return circuitBreaker.isOpen();
+	}
+
+	/**
+	 * Continue polling and consuming Kafka messages.
+	 */
+	public void resume() {
+		if (circuitBreaker == null) {
+			throw new IllegalStateException("KafkaConsumerService is missing circuit breaker.");
+		}
+		circuitBreaker.close();
+	}
+
+	/**
+	 * Register an event listener.  Alternatively, override event handler on Consumer.
+	 * @param listener
+	 */
+	public void registerEventListener(KafkaConsumerEventListener listener) {
+		listeners.add(listener);
+	}
+
+	private void notifyEventListeners(KafkaConsumerEvent event) {
+		listeners.forEach((listener) -> listener.eventNotification(event));
 	}
 }

--- a/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/circuitbreaker/CircuitBreaker.java
+++ b/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/circuitbreaker/CircuitBreaker.java
@@ -1,0 +1,22 @@
+package smartthings.ratpack.kafka.circuitbreaker;
+
+import ratpack.exec.Operation;
+
+/**
+ * CircuitBreaker interface.
+ */
+public interface CircuitBreaker {
+
+	void init(CircuitBreakerListener listener);
+
+	Operation blockIfOpen();
+
+	boolean isOpen();
+
+	void open();
+
+	void close();
+
+	void destroy();
+
+}

--- a/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/circuitbreaker/CircuitBreakerListener.java
+++ b/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/circuitbreaker/CircuitBreakerListener.java
@@ -1,0 +1,12 @@
+package smartthings.ratpack.kafka.circuitbreaker;
+
+/**
+ * Listener interface providing methods to be called when circuit changes state.
+ */
+public interface CircuitBreakerListener {
+
+	void opened();
+
+	void closed();
+
+}

--- a/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/circuitbreaker/SimpleCircuitBreaker.java
+++ b/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/circuitbreaker/SimpleCircuitBreaker.java
@@ -1,0 +1,101 @@
+package smartthings.ratpack.kafka.circuitbreaker;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ratpack.exec.Blocking;
+import ratpack.exec.Operation;
+
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Provides a simplistic implementation that allows suspension / resuming of polling operations.
+ */
+@ThreadSafe
+public class SimpleCircuitBreaker implements CircuitBreaker {
+	private static final Logger log = LoggerFactory.getLogger(SimpleCircuitBreaker.class);
+
+	private final Object mutex = new Object();
+
+	@GuardedBy("mutex")
+	private boolean open = false;
+
+	private CircuitBreakerListener listener;
+
+	@Override
+	public void init(CircuitBreakerListener listener) {
+		synchronized (mutex) {
+			log.debug("setting listener..");
+			this.listener = listener;
+		}
+	}
+
+	@Override
+	public void destroy() {
+		//do nothing
+	}
+
+	@Override
+	public Operation blockIfOpen() {
+		return Blocking.op(() -> {
+			synchronized (mutex) {
+				while (open) {
+					try {
+						log.debug("CircuitBreaker.blockIfOpen - calling wait");
+						mutex.wait();
+					} catch (InterruptedException e) {
+						//Intentionally left blank
+					}
+				}
+			}
+		});
+	}
+
+	@Override
+	public boolean isOpen() {
+		synchronized (mutex) {
+			return open;
+		}
+	}
+
+	@Override
+	public void open() {
+		synchronized (mutex) {
+			if (!open) {
+				open = true;
+				notifyOpened();
+				log.info("CircuitBreaker opened");
+				return;
+			}
+			log.info("CircuitBreaker already open");
+		}
+	}
+
+	@Override
+	public void close() {
+		synchronized (mutex) {
+			if (open) {
+				open = false;
+				notifyClosed();
+				log.info("CircuitBreaker closing");
+				mutex.notifyAll();
+				return;
+			}
+			log.info("CircuitBreaker already closed");
+		}
+	}
+
+	private void notifyOpened() {
+		if (listener != null) {
+			log.debug("notify open..");
+			listener.opened();
+		}
+	}
+
+	private void notifyClosed() {
+		if (listener != null) {
+			log.debug("notify close..");
+			listener.closed();
+		}
+	}
+}

--- a/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/circuitbreaker/package-info.java
+++ b/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/circuitbreaker/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Circuit breaker implementations used to support suspending and resuming polling operations in a running application.
+ */
+package smartthings.ratpack.kafka.circuitbreaker;

--- a/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/event/KafkaConsumerEvent.java
+++ b/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/event/KafkaConsumerEvent.java
@@ -1,0 +1,37 @@
+package smartthings.ratpack.kafka.event;
+
+/**
+ * Defines all possible events emitted by this Kafka consumer integration.
+ */
+public class KafkaConsumerEvent {
+
+	public static final KafkaConsumerEvent STARTED_EVENT = new KafkaConsumerEvent("Started");
+	public static final KafkaConsumerEvent STOPPED_EVENT = new KafkaConsumerEvent("Stopped");
+	public static final KafkaConsumerEvent SUSPENDED_EVENT = new KafkaConsumerEvent("Suspended");
+	public static final KafkaConsumerEvent RESUMED_EVENT = new KafkaConsumerEvent("Resumed");
+
+	private final String name;
+
+	private KafkaConsumerEvent(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (o == null || o.getClass() != getClass()) {
+			return false;
+		} else if (o == this || ((KafkaConsumerEvent) o).getName().equals(getName())) {
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public int hashCode() {
+		return name != null ? name.hashCode() : 0;
+	}
+}

--- a/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/event/KafkaConsumerEventListener.java
+++ b/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/event/KafkaConsumerEventListener.java
@@ -1,0 +1,8 @@
+package smartthings.ratpack.kafka.event;
+
+/**
+ * Functional interface for event notification.
+ */
+public interface KafkaConsumerEventListener {
+	void eventNotification(KafkaConsumerEvent event);
+}

--- a/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/event/package-info.java
+++ b/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/event/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains event definitions for RatPack Kafka Consumer module.
+ */
+package smartthings.ratpack.kafka.event;

--- a/ratpack-kafka-consumer/src/test/groovy/smartthings/ratpack/kafka/KafkaConsumerServiceFunctionalSpec.groovy
+++ b/ratpack-kafka-consumer/src/test/groovy/smartthings/ratpack/kafka/KafkaConsumerServiceFunctionalSpec.groovy
@@ -4,6 +4,8 @@ import groovy.util.logging.Slf4j
 import ratpack.groovy.test.embed.GroovyEmbeddedApp
 import ratpack.guice.Guice
 import ratpack.test.embed.EmbeddedApp
+import smartthings.ratpack.kafka.event.KafkaConsumerEvent
+import smartthings.ratpack.kafka.event.KafkaConsumerEventListener
 import smartthings.ratpack.kafka.fixtures.TestConsumer
 import smartthings.ratpack.kafka.fixtures.TestData
 import smartthings.ratpack.kafka.fixtures.TestProducerService
@@ -15,7 +17,7 @@ import spock.util.concurrent.BlockingVariable
 import java.time.Instant
 
 @Slf4j
-class KafkaConsumerServiceSpec extends Specification {
+class KafkaConsumerServiceFunctionalSpec extends Specification {
 
 	String getTestKafkaServers() {
 		return System.getenv("KAFKA_SERVER") ?: '127.0.0.1:9092'
@@ -24,15 +26,18 @@ class KafkaConsumerServiceSpec extends Specification {
 	private static final String CLIENT_ID = 'test-client'
 	private static final String GROUP_ID = 'test-client'
 	private static final String TOPIC = 'test'
-
-	private static final TestData data = new TestData(id: UUID.randomUUID().toString(), name: 'Hello World', timestamp: Instant.now().toEpochMilli())
+	private static final TestData DATA = new TestData(
+		id: UUID.randomUUID().toString(),
+		name: 'Hello World',
+		timestamp: Instant.now().toEpochMilli()
+	)
 
 	TestService testService = Mock(TestService)
 
 	TestConsumer testConsumer = new TestConsumer(testService, GROUP_ID, TOPIC)
 
-	@AutoCleanup
 	@Delegate
+	@AutoCleanup
 	EmbeddedApp app = GroovyEmbeddedApp.of({ spec ->
 		registry(Guice.registry { bindings ->
 			bindings.moduleConfig(KafkaConsumerModule, new KafkaConsumerModule.Config(), { config ->
@@ -49,7 +54,7 @@ class KafkaConsumerServiceSpec extends Specification {
 			post('produce') { ctx ->
 				TestProducerService producer = ctx.get(TestProducerService)
 				try {
-					producer.send(data)
+					producer.send(DATA)
 						.then({
 						ctx.render('ok')
 					})
@@ -57,10 +62,28 @@ class KafkaConsumerServiceSpec extends Specification {
 					ctx.error(t)
 				}
 			}
+			post('suspend') { ctx ->
+				KafkaConsumerService kafkaConsumerService = ctx.get(KafkaConsumerService)
+				try {
+					kafkaConsumerService.suspend()
+					ctx.render('ok')
+				} catch (Throwable t) {
+					ctx.error(t)
+				}
+			}
+			post('resume') { ctx ->
+				KafkaConsumerService kafkaConsumerService = ctx.get(KafkaConsumerService)
+				try {
+					kafkaConsumerService.resume()
+					ctx.render('ok')
+				} catch (Throwable t) {
+					ctx.error(t)
+				}
+			}
 		}
 	})
 
-	void 'it should consumer Kafka messages'() {
+	void 'it should consume Kafka messages'() {
 		given:
 		def done = new BlockingVariable(90)
 
@@ -76,8 +99,45 @@ class KafkaConsumerServiceSpec extends Specification {
 		log.debug("The call to the producer finished - [status: ${status}]")
 		assert status == 'ok'
 		def result = done.get()
-		assert result.id == data.id
-		assert result.name == data.name
-		assert result.timestamp == data.timestamp
+		assert result.id == DATA.id
+		assert result.name == DATA.name
+		assert result.timestamp == DATA.timestamp
+	}
+
+	void 'it should suspend and resume processing of Kafka messages'() {
+		given:
+		def done = new BlockingVariable(10)
+		String status
+		KafkaConsumerEventListener listener = Mock()
+
+		and:
+		List<KafkaConsumerEvent> events = []
+		listener.eventNotification(_ as KafkaConsumerEvent) >> { data ->
+			log.debug("Received ${data.first()} event!")
+			events.add((KafkaConsumerEvent) data.first())
+			if (events.size() == 3) {
+				done.set(events)
+			}
+		}
+
+		and:
+		testConsumer.addEventListener(listener)
+
+		when:
+		status = httpClient.postText('suspend')
+
+		then:
+		assert status == 'ok'
+
+		when:
+		status = httpClient.postText('resume')
+
+		then:
+		assert status == 'ok'
+		def result = (List<KafkaConsumerEvent>) done.get()
+		assert result.size() == 3
+		assert result.first() == KafkaConsumerEvent.STARTED_EVENT
+		assert result.get(1) == KafkaConsumerEvent.SUSPENDED_EVENT
+		assert result.get(2) == KafkaConsumerEvent.RESUMED_EVENT
 	}
 }

--- a/ratpack-kafka-consumer/src/test/groovy/smartthings/ratpack/kafka/circuitbreaker/SimpleCircuitBreakerSpec.groovy
+++ b/ratpack-kafka-consumer/src/test/groovy/smartthings/ratpack/kafka/circuitbreaker/SimpleCircuitBreakerSpec.groovy
@@ -1,0 +1,68 @@
+package smartthings.ratpack.kafka.circuitbreaker
+
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.util.concurrent.BlockingVariable
+
+class SimpleCircuitBreakerSpec extends Specification {
+
+	@Shared
+	SimpleCircuitBreaker circuitBreaker = new SimpleCircuitBreaker()
+
+	void 'it should know when closed'() {
+		when:
+		boolean open = circuitBreaker.isOpen()
+
+		then:
+		assert !open
+	}
+
+	void 'it should know when open'() {
+		when:
+		circuitBreaker.open()
+		boolean open = circuitBreaker.isOpen()
+
+		then:
+		assert open
+	}
+
+	void 'it should notify on state changes'() {
+		given:
+		BlockingVariable<Boolean> openDone = new BlockingVariable<>(3)
+		BlockingVariable<Boolean> closeDone = new BlockingVariable<>(3)
+		CircuitBreakerListener listener = new CircuitBreakerListener() {
+			@Override
+			void opened() {
+				openDone.set(true)
+			}
+
+			@Override
+			void closed() {
+				closeDone.set(true)
+			}
+		}
+
+		and:
+		circuitBreaker.init(listener)
+
+		when:
+		circuitBreaker.close()
+
+		then:
+		assert closeDone.get()
+
+		when:
+		circuitBreaker.open()
+
+		then:
+		assert openDone.get()
+	}
+
+	void 'it should destroy'() {
+		when:
+		circuitBreaker.destroy()
+
+		then:
+		noExceptionThrown()
+	}
+}

--- a/ratpack-kafka-consumer/src/test/groovy/smartthings/ratpack/kafka/event/KafkaConsumerEventSpec.groovy
+++ b/ratpack-kafka-consumer/src/test/groovy/smartthings/ratpack/kafka/event/KafkaConsumerEventSpec.groovy
@@ -1,0 +1,42 @@
+package smartthings.ratpack.kafka.event
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.nio.charset.StandardCharsets
+
+class KafkaConsumerEventSpec extends Specification {
+
+	@Unroll
+	void 'it should determine object equality'() {
+
+		when:
+		boolean bool = object1.equals(object2)
+
+		then:
+		assert bool == result
+
+		where:
+		object1                           |  object2                          | result
+		KafkaConsumerEvent.RESUMED_EVENT  |  KafkaConsumerEvent.STOPPED_EVENT | false
+		KafkaConsumerEvent.RESUMED_EVENT  |  KafkaConsumerEvent.RESUMED_EVENT | true
+		KafkaConsumerEvent.RESUMED_EVENT  |  StandardCharsets.UTF_8           | false
+		KafkaConsumerEvent.RESUMED_EVENT  |  null                             | false
+	}
+
+	@Unroll
+	void 'it should retrieve an event name'() {
+		when:
+		String name = event.getName()
+
+		then:
+		name == eventName
+
+		where:
+		event                              | eventName
+		KafkaConsumerEvent.STARTED_EVENT   | KafkaConsumerEvent.STARTED_EVENT.getName()
+		KafkaConsumerEvent.STOPPED_EVENT   | KafkaConsumerEvent.STOPPED_EVENT.getName()
+		KafkaConsumerEvent.SUSPENDED_EVENT | KafkaConsumerEvent.SUSPENDED_EVENT.getName()
+		KafkaConsumerEvent.RESUMED_EVENT   | KafkaConsumerEvent.RESUMED_EVENT.getName()
+	}
+}

--- a/ratpack-kafka-consumer/src/test/groovy/smartthings/ratpack/kafka/fixtures/TestConsumer.groovy
+++ b/ratpack-kafka-consumer/src/test/groovy/smartthings/ratpack/kafka/fixtures/TestConsumer.groovy
@@ -4,6 +4,8 @@ import com.google.inject.Inject
 import groovy.util.logging.Slf4j
 import org.apache.kafka.clients.consumer.ConsumerRecords
 import smartthings.ratpack.kafka.Consumer
+import smartthings.ratpack.kafka.event.KafkaConsumerEvent
+import smartthings.ratpack.kafka.event.KafkaConsumerEventListener
 
 @Slf4j
 class TestConsumer implements Consumer<byte[], byte[]> {
@@ -12,6 +14,7 @@ class TestConsumer implements Consumer<byte[], byte[]> {
 	final String[] topics
 
 	TestService testService
+	List<KafkaConsumerEventListener> listeners = new ArrayList<>();
 
 	@Inject
 	TestConsumer(TestService testService, String group, String topic) {
@@ -47,7 +50,17 @@ class TestConsumer implements Consumer<byte[], byte[]> {
 		}
 	}
 
+	@Override
 	Long getPollWaitTime() {
 		return 3000
+	}
+
+	@Override
+	void eventHandler(KafkaConsumerEvent event) {
+		listeners*.eventNotification(event)
+	}
+
+	void addEventListener(KafkaConsumerEventListener listener) {
+		listeners.add(listener)
 	}
 }


### PR DESCRIPTION
Pretty basic implementation based on [Konsumer's SimpleCircuitBreaker](https://github.com/SmartThingsOSS/konsumer/blob/master/src/main/java/smartthings/konsumer/circuitbreaker/SimpleCircuitBreaker.java)

Provides suspend and resume methods off of KafkaConsumerService to suspend/resume polling of Kafka for all configured consumers.
