### PR TITLE
Add static code analysis plugins: Findbugs, Pmd, and Checkstyle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ target/
 *.orig
 *~
 .DS_Store
+.gradletasknamecache

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 
 	dependencies {
 		classpath 'com.github.ben-manes:gradle-versions-plugin:0.12.0'
-    classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
+		classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
 	}
 }
 
@@ -24,19 +24,15 @@ task wrapper(type: Wrapper) {
 }
 
 subprojects {
-
-
 	group = "smartthings"
 	version = rootProject.file('version.txt').text.trim()
 
 	apply plugin: "base"
 	apply plugin: "groovy"
-	apply plugin: "maven-publish"
-	apply plugin: "jacoco"
 	apply plugin: 'idea'
 	apply plugin: 'com.github.ben-manes.versions'
-  apply from: rootProject.file('gradle/publishing.gradle')
-
+	apply from: rootProject.file('gradle/publishing.gradle')
+	apply from: rootProject.file('gradle/convention.gradle')
 
 	sourceCompatibility = "1.8"
 	targetCompatibility = "1.8"
@@ -44,11 +40,5 @@ subprojects {
 	repositories {
 		mavenLocal()
 		jcenter()
-	}
-
-	jacocoTestReport {
-  	reports {
-	    xml.enabled true
-		}
 	}
 }

--- a/circle.yml
+++ b/circle.yml
@@ -35,6 +35,7 @@ test:
 
   post:
     - 'find . -type f -name "*.xml" | grep "build/test-results" | xargs cp -t $CIRCLE_TEST_REPORTS/'
+    - 'find . -type f \( -name "*.html" -or -name "*.xml" \) | grep "build/coverage" | xargs cp --parents -t $CIRCLE_TEST_REPORTS/'
     - bash <(curl -s https://codecov.io/bash)
     - docker-compose logs >> $CIRCLE_ARTIFACTS/docker-compose.log
 

--- a/gradle/checkstyle/checkstyle.xml
+++ b/gradle/checkstyle/checkstyle.xml
@@ -1,0 +1,295 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC
+		"-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+		"http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<!-- This is a checkstyle configuration file. For descriptions of
+what the following rules do, please see the checkstyle configuration
+page at http://checkstyle.sourceforge.net/config.html -->
+
+<!--
+https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/google_checks.xml
+-->
+
+<module name="Checker">
+
+	<!--<module name="FileTabCharacter">-->
+		<!--Checks that there are no tab characters in the file.-->
+	<!--</module>-->
+
+	<module name="NewlineAtEndOfFile">
+		<property name="lineSeparator" value="lf"/>
+	</module>
+
+	<module name="RegexpSingleline">
+		<!-- Checks that FIXME is not used in comments.  TODO is preferred.
+		-->
+		<property name="format" value="((//.*)|(\*.*))FIXME" />
+		<property name="message" value='TODO is preferred to FIXME.  e.g. "TODO(johndoe): Refactor when v2 is released."' />
+	</module>
+
+	<module name="JavadocPackage">
+		<!-- Checks that each Java package has a Javadoc file used for commenting.
+		  Only allows a package-info.java, not package.html. -->
+	</module>
+
+	<!-- All Java AST specific tests live under TreeWalker module. -->
+	<module name="TreeWalker">
+		<property name="tabWidth" value="1"/>
+		<!--
+		IMPORT CHECKS
+		-->
+
+		<module name="RedundantImport">
+			<!-- Checks for redundant import statements. -->
+			<property name="severity" value="error"/>
+		</module>
+
+		<!--
+		JAVADOC CHECKS
+		-->
+
+		<!-- Checks for Javadoc comments.                     -->
+		<!-- See http://checkstyle.sf.net/config_javadoc.html -->
+		<module name="JavadocMethod">
+			<property name="scope" value="protected"/>
+			<property name="severity" value="warning"/>
+			<property name="allowMissingJavadoc" value="true"/>
+			<property name="allowMissingParamTags" value="true"/>
+			<property name="allowMissingReturnTag" value="true"/>
+			<property name="allowMissingThrowsTags" value="true"/>
+			<property name="allowThrowsTagsForSubclasses" value="true"/>
+			<property name="allowUndeclaredRTE" value="true"/>
+		</module>
+
+		<module name="JavadocType">
+			<property name="scope" value="protected"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="JavadocStyle">
+			<property name="severity" value="warning"/>
+		</module>
+
+		<!--
+		NAMING CHECKS
+		-->
+
+		<!-- Item 38 - Adhere to generally accepted naming conventions -->
+
+		<module name="PackageName">
+			<!-- Validates identifiers for package names against the
+				supplied expression. -->
+			<!-- Here the default checkstyle rule restricts package name parts to
+				seven characters, this is not in line with common practice at Google.
+			  -->
+			<property name="format" value="^[a-z]+(\.[a-z][a-z0-9]{1,})*$"/>
+			<property name="severity" value="warning"/>
+		</module>
+
+		<module name="TypeNameCheck">
+			<!-- Validates static, final fields against the
+			  expression "^[A-Z][a-zA-Z0-9]*$". -->
+			<metadata name="altname" value="TypeName"/>
+			<property name="severity" value="warning"/>
+		</module>
+
+		<module name="ConstantNameCheck">
+			<!-- Validates non-private, static, final fields against the supplied
+			  public/package final fields "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$". -->
+			<metadata name="altname" value="ConstantName"/>
+			<property name="applyToPublic" value="true"/>
+			<property name="applyToProtected" value="true"/>
+			<property name="applyToPackage" value="true"/>
+			<property name="applyToPrivate" value="false"/>
+			<property name="format" value="^([A-Z][A-Z0-9]*(_[A-Z0-9]+)*|FLAG_.*)$"/>
+			<message key="name.invalidPattern"
+					 value="Variable ''{0}'' should be in ALL_CAPS (if it is a constant) or be private (otherwise)."/>
+			<property name="severity" value="warning"/>
+		</module>
+
+		<module name="StaticVariableNameCheck">
+			<!-- Validates static, non-final fields against the supplied
+			  expression "^[a-z][a-zA-Z0-9]*_?$". -->
+			<metadata name="altname" value="StaticVariableName"/>
+			<property name="applyToPublic" value="true"/>
+			<property name="applyToProtected" value="true"/>
+			<property name="applyToPackage" value="true"/>
+			<property name="applyToPrivate" value="true"/>
+			<property name="format" value="^[a-z][a-zA-Z0-9]*_?$"/>
+			<property name="severity" value="warning"/>
+		</module>
+
+		<module name="MemberNameCheck">
+			<!-- Validates non-static members against the supplied expression. -->
+			<metadata name="altname" value="MemberName"/>
+			<property name="applyToPublic" value="true"/>
+			<property name="applyToProtected" value="true"/>
+			<property name="applyToPackage" value="true"/>
+			<property name="applyToPrivate" value="true"/>
+			<property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
+			<property name="severity" value="warning"/>
+		</module>
+
+		<module name="MethodNameCheck">
+			<!-- Validates identifiers for method names. -->
+			<metadata name="altname" value="MethodName"/>
+			<property name="format" value="^[a-z][a-zA-Z0-9]*(_[a-zA-Z0-9]+)*$"/>
+			<property name="severity" value="warning"/>
+		</module>
+
+		<module name="ParameterName">
+			<!-- Validates identifiers for method parameters against the
+				expression "^[a-z][a-zA-Z0-9]*$". -->
+			<property name="severity" value="warning"/>
+		</module>
+
+		<module name="LocalFinalVariableName">
+			<!-- Validates identifiers for local final variables against the
+				expression "^[a-z][a-zA-Z0-9]*$". -->
+			<property name="severity" value="warning"/>
+		</module>
+
+		<module name="LocalVariableName">
+			<!-- Validates identifiers for local variables against the
+				expression "^[a-z][a-zA-Z0-9]*$". -->
+			<property name="severity" value="warning"/>
+		</module>
+
+
+		<!--
+		LENGTH and CODING CHECKS
+		-->
+
+		<module name="LineLength">
+			<!-- Checks if a line is too long. -->
+			<property name="max" value="${com.puppycrawl.tools.checkstyle.checks.sizes.LineLength.max}" default="120"/>
+			<property name="severity" value="error"/>
+
+			<!--
+				The default ignore pattern exempts the following elements:
+				  - import statements
+				  - long URLs inside comments
+			  -->
+
+			<property name="ignorePattern"
+					  value="${com.puppycrawl.tools.checkstyle.checks.sizes.LineLength.ignorePattern}"
+					  default="^(package .*;\s*)|(import .*;\s*)|( *(\*|//).*https?://.*)$"/>
+		</module>
+
+		<module name="LeftCurly">
+			<!-- Checks for placement of the left curly brace ('{'). -->
+			<property name="severity" value="warning"/>
+		</module>
+
+		<module name="RightCurly">
+			<!-- Checks right curlies on CATCH, ELSE, and TRY blocks are on
+			  the same line. e.g., the following example is fine:
+			  <pre>
+				if {
+				  ...
+				} else
+			  </pre>
+			  -->
+			<!-- This next example is not fine:
+			  <pre>
+				if {
+				  ...
+				}
+				else
+			  </pre>
+			  -->
+			<property name="option" value="same"/>
+			<property name="severity" value="warning"/>
+		</module>
+
+		<!-- Checks for braces around if and else blocks -->
+		<module name="NeedBraces">
+			<property name="severity" value="warning"/>
+			<property name="tokens" value="LITERAL_IF, LITERAL_ELSE, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO"/>
+		</module>
+
+		<module name="UpperEll">
+			<!-- Checks that long constants are defined with an upper ell.-->
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="FallThrough">
+			<!-- Warn about falling through to the next case statement.  Similar to
+			  javac -Xlint:fallthrough, but the check is suppressed if a single-line comment
+			  on the last non-blank line preceding the fallen-into case contains 'fall through' (or
+			  some other variants which we don't publicized to promote consistency).
+			  -->
+			<property name="reliefPattern"
+					  value="fall through|Fall through|fallthru|Fallthru|falls through|Falls through|fallthrough|Fallthrough|No break|NO break|no break|continue on"/>
+			<property name="severity" value="error"/>
+		</module>
+
+
+		<!--
+		MODIFIERS CHECKS
+		-->
+
+		<module name="ModifierOrder">
+			<!-- Warn if modifier order is inconsistent with JLS3 8.1.1, 8.3.1, and
+				   8.4.3.  The prescribed order is:
+				   public, protected, private, abstract, static, final, transient, volatile,
+				   synchronized, native, strictfp
+				-->
+		</module>
+
+
+		<!--
+		WHITESPACE CHECKS
+		-->
+
+		<module name="WhitespaceAround">
+			<!-- Checks that various tokens are surrounded by whitespace.
+				   This includes most binary operators and keywords followed
+				   by regular or curly braces.
+			  -->
+			<property name="tokens" value="ASSIGN, BAND, BAND_ASSIGN, BOR,
+        BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN,
+        EQUAL, GE, GT, LAND, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE,
+        LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN,
+        LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS,
+        MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION,
+        SL, SL_ASSIGN, SR_ASSIGN, STAR, STAR_ASSIGN"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="WhitespaceAfter">
+			<!-- Checks that commas, semicolons and typecasts are followed by
+				   whitespace.
+			  -->
+			<property name="tokens" value="COMMA, SEMI, TYPECAST"/>
+		</module>
+
+		<module name="NoWhitespaceAfter">
+			<!-- Checks that there is no whitespace after various unary operators.
+				   Linebreaks are allowed.
+			  -->
+			<property name="tokens" value="BNOT, DEC, DOT, INC, LNOT, UNARY_MINUS,
+        UNARY_PLUS"/>
+			<property name="allowLineBreaks" value="true"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="NoWhitespaceBefore">
+			<!-- Checks that there is no whitespace before various unary operators.
+				   Linebreaks are allowed.
+			  -->
+			<property name="tokens" value="SEMI, DOT, POST_DEC, POST_INC"/>
+			<property name="allowLineBreaks" value="true"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="ParenPad">
+			<!-- Checks that there is no whitespace before close parens or after
+				   open parens.
+			  -->
+			<property name="severity" value="warning"/>
+		</module>
+
+	</module>
+</module>

--- a/gradle/convention.gradle
+++ b/gradle/convention.gradle
@@ -1,0 +1,62 @@
+apply plugin: 'findbugs'
+apply plugin: "pmd"
+apply plugin: "checkstyle"
+apply plugin: "jacoco"
+
+sourceCompatibility = '1.8'
+targetCompatibility = '1.8'
+
+findbugs {
+	toolVersion = "3.0.1"
+	ignoreFailures = false
+	effort = "max"
+	reportLevel = "low"
+	excludeFilter = file("$rootProject.projectDir/gradle/findbugs/excludeFilter.xml")
+	sourceSets = [sourceSets.main]
+	reportsDir = file("$project.buildDir/coverage/findbugs")
+}
+
+checkstyle {
+	configFile = file("$rootProject.projectDir/gradle/checkstyle/checkstyle.xml")
+	reportsDir = file("$project.buildDir/coverage/checkstyle")
+}
+
+pmd {
+	ignoreFailures = false
+	reportsDir = file("$project.buildDir/coverage/pmd")
+}
+
+tasks.withType(FindBugs) {
+	reports {
+		xml.enabled = false
+		html.enabled = true
+	}
+}
+
+jacocoTestReport {
+	reports {
+		xml.enabled true
+	}
+}
+
+task wrapper(type: Wrapper) {
+	gradleVersion = "2.3"
+}
+
+configurations.all {
+	resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+		exclude group: 'log4j', module: 'log4j'
+		if (details.requested.name == 'groovy') {
+			details.useTarget group: details.requested.group, name: 'groovy-all', version: groovyVersion
+		}
+		if (details.requested.name == 'groovy-all') {
+			details.useVersion groovyVersion
+		}
+		if (details.requested.name == 'slf4j-log4j12') {
+			details.useTarget "org.slf4j:log4j-over-slf4j:${slf4jVersion}"
+		}
+		if (details.requested.name == 'log4j') {
+			details.useTarget "org.slf4j:log4j-over-slf4j:${slf4jVersion}"
+		}
+	}
+}

--- a/gradle/findbugs/excludeFilter.xml
+++ b/gradle/findbugs/excludeFilter.xml
@@ -1,0 +1,5 @@
+<FindBugsFilter>
+	<Match>
+		<Bug pattern="SE_NO_SERIALVERSIONID" />
+	</Match>
+</FindBugsFilter>

--- a/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/KafkaConsumerModule.java
+++ b/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/KafkaConsumerModule.java
@@ -7,12 +7,18 @@ import ratpack.guice.ConfigurableModule;
 import java.util.Properties;
 import java.util.Set;
 
+/**
+ * Guice module bindings for the RatPack Kafka consumer library.
+ */
 public class KafkaConsumerModule extends ConfigurableModule<KafkaConsumerModule.Config> {
 
 	protected void configure() {
 		bind(KafkaConsumerService.class).in(Scopes.SINGLETON);
 	}
 
+	/**
+	 * Primary configuration object for RatPack Kafka Consumer module.
+	 */
 	public static class Config {
 
 		Set<String> servers;

--- a/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/package-info.java
+++ b/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * RatPack module to ease consumption of Kafka messages.
+ */
+package smartthings.ratpack.kafka;

--- a/ratpack-kafka-producer/src/main/java/smartthings/ratpack/kafka/KafkaProducerModule.java
+++ b/ratpack-kafka-producer/src/main/java/smartthings/ratpack/kafka/KafkaProducerModule.java
@@ -7,6 +7,9 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Guice module bindings for the RatPack Kafka producer library.
+ */
 public class KafkaProducerModule extends ConfigurableModule<KafkaProducerModule.Config> {
 
 	@Override
@@ -14,6 +17,9 @@ public class KafkaProducerModule extends ConfigurableModule<KafkaProducerModule.
 		bind(KafkaProducerService.class).in(Scopes.SINGLETON);
 	}
 
+	/**
+	 * Primary configuration object for RatPack Kafka Producer module.
+	 */
 	public static class Config {
 
 		Set<String> servers;

--- a/ratpack-kafka-producer/src/main/java/smartthings/ratpack/kafka/KafkaProducerService.java
+++ b/ratpack-kafka-producer/src/main/java/smartthings/ratpack/kafka/KafkaProducerService.java
@@ -10,6 +10,9 @@ import ratpack.service.Service;
 import ratpack.service.StartEvent;
 import ratpack.service.StopEvent;
 
+/**
+ * Service class to wrap logic of interacting with Kafka to produce messages.
+ */
 public class KafkaProducerService implements Service {
 
 	private KafkaProducer<byte[], byte[]> kafkaProducer;

--- a/ratpack-kafka-producer/src/main/java/smartthings/ratpack/kafka/package-info.java
+++ b/ratpack-kafka-producer/src/main/java/smartthings/ratpack/kafka/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * RatPack module to ease producing of Kafka messages.
+ */
+package smartthings.ratpack.kafka;


### PR DESCRIPTION
- Project currently didn't have any Findbug or Pmd warnings.
- Applied checkstyles using Google's defaults, and then made adjustments for tabs over spaces.
  - Forces Javadoc comments which is probably good for an OSS project. 
