### PR TITLE
Add ability to enable/disable kafka client via configuration.

### DIFF
--- a/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/KafkaConsumerModule.java
+++ b/ratpack-kafka-consumer/src/main/java/smartthings/ratpack/kafka/KafkaConsumerModule.java
@@ -25,6 +25,7 @@ public class KafkaConsumerModule extends ConfigurableModule<KafkaConsumerModule.
 	public static class Config {
 
 		Set<String> servers;
+		boolean enabled = true;
 
 		public Config() {
 		}
@@ -45,6 +46,14 @@ public class KafkaConsumerModule extends ConfigurableModule<KafkaConsumerModule.
 
 		public void setServers(Set<String> servers) {
 			this.servers = servers;
+		}
+
+		public boolean isEnabled() {
+			return enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
 		}
 	}
 

--- a/ratpack-kafka-consumer/src/test/groovy/smartthings/ratpack/kafka/KafkaConsumerServiceSpec.groovy
+++ b/ratpack-kafka-consumer/src/test/groovy/smartthings/ratpack/kafka/KafkaConsumerServiceSpec.groovy
@@ -1,0 +1,44 @@
+package smartthings.ratpack.kafka
+
+import com.google.common.reflect.TypeToken
+import ratpack.registry.Registry
+import ratpack.service.StartEvent
+import smartthings.ratpack.kafka.circuitbreaker.CircuitBreaker
+import smartthings.ratpack.kafka.circuitbreaker.SimpleCircuitBreaker
+import spock.lang.Specification
+
+class KafkaConsumerServiceSpec extends Specification {
+
+	void 'it should not startup when config marked as disabled'() {
+		given:
+		KafkaConsumerModule.Config config = new KafkaConsumerModule.Config()
+		config.setEnabled(false);
+		KafkaConsumerService service = new KafkaConsumerService(config)
+		StartEvent event = Mock(StartEvent)
+
+		when:
+		service.onStart(event)
+
+		then:
+		0 * _
+	}
+
+	void 'it should call startup when config marked as enabled'() {
+		given:
+		KafkaConsumerModule.Config config = new KafkaConsumerModule.Config()
+		config.setEnabled(true);
+		KafkaConsumerService service = new KafkaConsumerService(config)
+		StartEvent event = Mock()
+		Registry registry = Mock()
+		CircuitBreaker breaker = new SimpleCircuitBreaker();
+
+		when:
+		service.onStart(event)
+
+		then:
+		_ * event.getRegistry() >> registry
+		1 * registry.getAll(TypeToken.of(Consumer.class)) >> []
+		1 * registry.get(CircuitBreaker.class) >> breaker
+		0 * _
+	}
+}

--- a/ratpack-kafka-producer/src/main/java/smartthings/ratpack/kafka/KafkaProducerModule.java
+++ b/ratpack-kafka-producer/src/main/java/smartthings/ratpack/kafka/KafkaProducerModule.java
@@ -25,6 +25,7 @@ public class KafkaProducerModule extends ConfigurableModule<KafkaProducerModule.
 		Set<String> servers;
 		String clientId;
 		Long maxBlockMillis = TimeUnit.MINUTES.toMillis(1);
+		boolean enabled = true;
 
 		public Config() {
 		}
@@ -63,6 +64,14 @@ public class KafkaProducerModule extends ConfigurableModule<KafkaProducerModule.
 
 		public void setMaxBlockMillis(Long maxBlockMillis) {
 			this.maxBlockMillis = maxBlockMillis;
+		}
+
+		public boolean isEnabled() {
+			return enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
 		}
 	}
 }


### PR DESCRIPTION
Add ability to completely disable kafka integration preventing Consumer/Producer from starting up.  This is useful for feature flagging, or enable/disabling per environment.
