### PR TITLE
Add additional config properties to KafkaProducerModule.java

### DIFF
--- a/ratpack-kafka-producer/src/main/java/smartthings/ratpack/kafka/KafkaProducerModule.java
+++ b/ratpack-kafka-producer/src/main/java/smartthings/ratpack/kafka/KafkaProducerModule.java
@@ -22,15 +22,22 @@ public class KafkaProducerModule extends ConfigurableModule<KafkaProducerModule.
 	 */
 	public static class Config {
 
-		Set<String> servers;
-		String clientId;
-		Long maxBlockMillis = TimeUnit.MINUTES.toMillis(1);
-		boolean enabled = true;
+		private Set<String> servers;
+		private String clientId;
+		private Long maxBlockMillis = TimeUnit.MINUTES.toMillis(1);
+		private boolean enabled = true;
+		private Long lingersMs;
+		private Integer batchSize;
+		private Integer sendBufferBytes;
+		private Integer maxInFlightRequestsPerConnection;
+		private Long bufferMemory;
+		private String acks;
 
 		public Config() {
 		}
 
 		public Properties getKafkaProperties() {
+
 			Properties props = new Properties();
 
 			props.put("bootstrap.servers", String.join(",", servers));
@@ -38,6 +45,24 @@ public class KafkaProducerModule extends ConfigurableModule<KafkaProducerModule.
 			props.put("key.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
 			props.put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
 			props.put("max.block.ms", maxBlockMillis);
+			if (lingersMs != null) {
+				props.put("linger.ms", lingersMs);
+			}
+			if (batchSize != null) {
+				props.put("batch.size", batchSize);
+			}
+			if (sendBufferBytes != null) {
+				props.put("send.buffer.bytes", sendBufferBytes);
+			}
+			if (maxInFlightRequestsPerConnection != null) {
+				props.put("max.in.flight.requests.per.connection", maxInFlightRequestsPerConnection);
+			}
+			if (bufferMemory != null) {
+				props.put("buffer.memory", bufferMemory);
+			}
+			if (acks != null && !acks.isEmpty()) {
+				props.put("acks", acks);
+			}
 
 			return props;
 		}
@@ -72,6 +97,54 @@ public class KafkaProducerModule extends ConfigurableModule<KafkaProducerModule.
 
 		public void setEnabled(boolean enabled) {
 			this.enabled = enabled;
+		}
+
+		public Long getLingersMs() {
+			return lingersMs;
+		}
+
+		public void setLingersMs(Long lingersMs) {
+			this.lingersMs = lingersMs;
+		}
+
+		public Integer getBatchSize() {
+			return batchSize;
+		}
+
+		public void setBatchSize(Integer batchSize) {
+			this.batchSize = batchSize;
+		}
+
+		public Integer getSendBufferBytes() {
+			return sendBufferBytes;
+		}
+
+		public void setSendBufferBytes(Integer sendBufferBytes) {
+			this.sendBufferBytes = sendBufferBytes;
+		}
+
+		public Integer getMaxInFlightRequestsPerConnection() {
+			return maxInFlightRequestsPerConnection;
+		}
+
+		public void setMaxInFlightRequestsPerConnection(Integer maxInFlightRequestsPerConnection) {
+			this.maxInFlightRequestsPerConnection = maxInFlightRequestsPerConnection;
+		}
+
+		public Long getBufferMemory() {
+			return bufferMemory;
+		}
+
+		public void setBufferMemory(Long bufferMemory) {
+			this.bufferMemory = bufferMemory;
+		}
+
+		public String getAcks() {
+			return acks;
+		}
+
+		public void setAcks(String acks) {
+			this.acks = acks;
 		}
 	}
 }

--- a/ratpack-kafka-producer/src/main/java/smartthings/ratpack/kafka/KafkaProducerService.java
+++ b/ratpack-kafka-producer/src/main/java/smartthings/ratpack/kafka/KafkaProducerService.java
@@ -50,4 +50,8 @@ public class KafkaProducerService implements Service {
 			kafkaProducer.send(new ProducerRecord<>(topic, partition, timestamp, key, value)).get()
 		);
 	}
+
+	public KafkaProducerModule.Config getConfig() {
+		return config;
+	}
 }

--- a/ratpack-kafka-producer/src/test/groovy/smartthings/ratpack/kafka/KafkaProducerServiceSpec.groovy
+++ b/ratpack-kafka-producer/src/test/groovy/smartthings/ratpack/kafka/KafkaProducerServiceSpec.groovy
@@ -7,6 +7,7 @@ import ratpack.service.StopEvent
 import ratpack.test.exec.ExecHarness
 import spock.lang.AutoCleanup
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class KafkaProducerServiceSpec extends Specification {
 
@@ -122,7 +123,7 @@ class KafkaProducerServiceSpec extends Specification {
 		noExceptionThrown()
 	}
 
-	def "should throw IllegalStateExeception when message sent while disabled"() {
+	def "should throw IllegalStateException when message sent while disabled"() {
 		given:
 		KafkaProducerModule.Config config = new KafkaProducerModule.Config()
 		config.setClientId("test_clientId")
@@ -155,5 +156,275 @@ class KafkaProducerServiceSpec extends Specification {
 		assert result.error
 		assert result.throwable.getClass() == IllegalStateException
 		assert result.throwable.getMessage() == 'KafkaProducer is currently not available.'
+	}
+
+	def "Can send a message with optional properties"() {
+		given:
+		KafkaProducerModule.Config config = new KafkaProducerModule.Config()
+		config.setClientId("test_clientId")
+		config.setServers([getTestKafkaServers()] as Set<String>)
+		config.setMaxBlockMillis(1000L)
+		config.setLingersMs(0)
+		config.setBatchSize(16384)
+		config.setSendBufferBytes(131072)
+		config.setMaxInFlightRequestsPerConnection(5)
+		config.setBufferMemory(33554432)
+		config.setAcks("1")
+
+		KafkaProducerService service
+		byte[] key = "fake_key".bytes
+		byte[] value = "fake_value".bytes
+
+		when:
+		def result = harness.yield {
+			service = new KafkaProducerService(config)
+			service.onStart(new StartEvent() {
+				@Override
+				Registry getRegistry() {
+					return Registry.empty()
+				}
+
+				@Override
+				boolean isReload() {
+					return false
+				}
+			})
+			return service.send("test", null, null, key, value)
+		}
+
+		then:
+		result.getValueOrThrow()
+	}
+
+	def "check for correct assignment(optional and mandatory fields) in kafka properties"() {
+		String clientId="test_clientId"
+		Set<String> servers=[getTestKafkaServers()] as Set<String>
+		Long maxBlockMillis=1000L
+		Long lingersMs=0;
+		int batchSize=1234;
+		int sendBufferBytes=134567;
+		int maxInFlightRequestsPerConnection=5;
+		Long bufferMemory=3352;
+		String acks="0";
+
+		given:
+		KafkaProducerModule.Config config = new KafkaProducerModule.Config()
+		config.setClientId(clientId)
+		config.setServers(servers)
+		config.setMaxBlockMillis(maxBlockMillis)
+		config.setLingersMs(lingersMs)
+		config.setBatchSize(batchSize)
+		config.setSendBufferBytes(sendBufferBytes)
+		config.setMaxInFlightRequestsPerConnection(maxInFlightRequestsPerConnection)
+		config.setBufferMemory(bufferMemory)
+		config.setAcks(acks)
+
+		when:
+		def props = config.getProperties()
+
+		then:
+		props.get("kafkaProperties").iterator().size() == 11
+		props.get("servers")==servers
+		props.get("clientId")==clientId
+		props.get("maxBlockMillis")==maxBlockMillis
+		props.get("lingersMs")==lingersMs
+		props.get("batchSize")==batchSize
+		props.get("sendBufferBytes")==sendBufferBytes
+		props.get("maxInFlightRequestsPerConnection")==maxInFlightRequestsPerConnection
+		props.get("bufferMemory")==bufferMemory
+		props.get("acks")==acks
+	}
+
+	def "check for correct assignment(only mandatory fields) in kafka properties"() {
+		String clientId="test_clientId"
+		Set<String> servers=[getTestKafkaServers()] as Set<String>
+		Long maxBlockMillis=1000L
+
+		given:
+		KafkaProducerModule.Config config = new KafkaProducerModule.Config()
+		config.setClientId(clientId)
+		config.setServers(servers)
+		config.setMaxBlockMillis(maxBlockMillis)
+
+		when:
+		def props = config.getProperties()
+
+		then:
+		props.get("kafkaProperties").iterator().size() == 5
+		props.get("servers")==servers
+		props.get("clientId")==clientId
+		props.get("maxBlockMillis")==maxBlockMillis
+		props.get("lingersMs")==null
+		props.get("batchSize")==null
+		props.get("sendBufferBytes")==null
+		props.get("maxInFlightRequestsPerConnection")==null
+		props.get("bufferMemory")==null
+		props.get("acks")==null
+	}
+
+	def "Can set and retrieve configs"() {
+		Long lingersMs=0;
+		int batchSize=16384;
+		int sendBufferBytes=131072;
+		int maxInFlightRequestsPerConnection=5;
+		Long bufferMemory=33554432;
+		String acks="1";
+
+		given:
+		KafkaProducerModule.Config config = new KafkaProducerModule.Config()
+		config.setClientId("test_clientId")
+		config.setServers([getTestKafkaServers()] as Set<String>)
+		config.setMaxBlockMillis(1000L)
+		config.setLingersMs(lingersMs)
+		config.setBatchSize(batchSize)
+		config.setSendBufferBytes(sendBufferBytes)
+		config.setMaxInFlightRequestsPerConnection(maxInFlightRequestsPerConnection)
+		config.setBufferMemory(bufferMemory)
+		config.setAcks(acks)
+
+		KafkaProducerService service
+
+		when:
+		service = new KafkaProducerService(config)
+
+		then:
+		lingersMs == service.getConfig().getLingersMs()
+		batchSize == service.getConfig().getBatchSize()
+		sendBufferBytes == service.getConfig().getSendBufferBytes()
+		maxInFlightRequestsPerConnection == service.getConfig().getMaxInFlightRequestsPerConnection()
+		bufferMemory == service.getConfig().getBufferMemory()
+		acks == service.getConfig().getAcks()
+	}
+
+	@Unroll
+	def "Can send a message with null #property"() {
+		given:
+		KafkaProducerModule.Config config = new KafkaProducerModule.Config()
+		config.setClientId("test_clientId")
+		config.setServers([getTestKafkaServers()] as Set<String>)
+		config.setMaxBlockMillis(1000L)
+		config.setLingersMs(0)
+		config.setBatchSize(16384)
+		config.setSendBufferBytes(131072)
+		config.setMaxInFlightRequestsPerConnection(5)
+		config.setBufferMemory(33554432)
+		config.setAcks("1")
+
+		and:
+		config[property] = null
+
+		KafkaProducerService service
+		byte[] key = "fake_key".bytes
+		byte[] value = "fake_value".bytes
+
+		when:
+		def result = harness.yield {
+			service = new KafkaProducerService(config)
+			service.onStart(new StartEvent() {
+				@Override
+				Registry getRegistry() {
+					return Registry.empty()
+				}
+
+				@Override
+				boolean isReload() {
+					return false
+				}
+			})
+			return service.send("test", null, null, key, value)
+		}
+
+		then:
+		result.getValueOrThrow()
+
+		where:
+		property << ['lingersMs', 'batchSize', 'sendBufferBytes',
+					 'maxInFlightRequestsPerConnection', 'bufferMemory', 'acks']
+	}
+
+	@Unroll
+	def "should throw ConfigException for negative #property value when message sent"() {
+		given:
+		KafkaProducerModule.Config config = new KafkaProducerModule.Config()
+		config.setClientId("test_clientId")
+		config.setServers([getTestKafkaServers()] as Set<String>)
+		config.setMaxBlockMillis(1000L)
+		config.setAcks("1")
+
+		KafkaProducerService service
+		byte[] key = "fake_key".bytes
+		byte[] value = "fake_value".bytes
+
+		and:
+		config[property] = -1
+
+		when:
+		def result = harness.yield {
+			service = new KafkaProducerService(config)
+			service.onStart(new StartEvent() {
+				@Override
+				Registry getRegistry() {
+					return Registry.empty()
+				}
+
+				@Override
+				boolean isReload() {
+					return false
+				}
+			})
+			return service.send("test", null, null, key, value)
+		}
+
+		then:
+		assert result.error
+		assert result.throwable.getClass() == org.apache.kafka.common.config.ConfigException
+		assert result.throwable.getMessage().contains('Invalid value -1')
+
+		where:
+		property << ['lingersMs', 'batchSize', 'sendBufferBytes', 'maxInFlightRequestsPerConnection', 'bufferMemory']
+	}
+
+	@Unroll
+	def "Can send a message with empty #property"() {
+		given:
+		KafkaProducerModule.Config config = new KafkaProducerModule.Config()
+		config.setClientId("test_clientId")
+		config.setServers([getTestKafkaServers()] as Set<String>)
+		config.setMaxBlockMillis(1000L)
+		config.setLingersMs(0)
+		config.setBatchSize(16384)
+		config.setSendBufferBytes(131072)
+		config.setMaxInFlightRequestsPerConnection(5)
+		config.setBufferMemory(33554432)
+
+		KafkaProducerService service
+		byte[] key = "fake_key".bytes
+		byte[] value = "fake_value".bytes
+
+		and:
+		config[property] = ""
+
+		when:
+		def result = harness.yield {
+			service = new KafkaProducerService(config)
+			service.onStart(new StartEvent() {
+				@Override
+				Registry getRegistry() {
+					return Registry.empty()
+				}
+
+				@Override
+				boolean isReload() {
+					return false
+				}
+			})
+			return service.send("test", null, null, key, value)
+		}
+
+		then:
+		result.getValueOrThrow()
+
+		where:
+		property << ['acks']
 	}
 }


### PR DESCRIPTION
These are required to achieve better throughput and latency, as well as durability control. The defaults below come from Kafka's implementation (as of 0.10.0.0), so that they won't break existing applications using the library.
- linger.ms (long, default 0)
- batch.size (int, default 16384)
- send.buffer.bytes (int, default 131072)
- max.in.flight.requests.per.connection (int, default 5)
- buffer.memory (long, default 33554432)
- acks (string, default 1)

fix optional variables and naming conventions

add test for delivering message with optional properties
